### PR TITLE
fix: new grpc client is accidentally closed when updating new config

### DIFF
--- a/pkg/client/grpc.go
+++ b/pkg/client/grpc.go
@@ -31,14 +31,7 @@ func (c *GrpcCfg[T]) WithFactory(clientFactory func(grpc.ClientConnInterface) T)
 
 func (*GrpcCfg[T]) OnUpdate(old, new *GrpcCfg[T]) {
 	ctx := context.Background()
-	var err error
-	new.grpcClient, err = grpcclient.New(new.clientFactory, grpcclient.WithConfig(&new.Config))
-	if err != nil {
-		klog.Errorf(ctx, "GrpcCfg.OnUpdate|grpcclient.New failed|err=%v", err)
-		return
-	}
 
-	new.C = new.grpcClient.C
 	if old != nil {
 		oldGrpcClient := old.grpcClient
 		time.AfterFunc(GrpcCloseDelay, func() {
@@ -47,4 +40,13 @@ func (*GrpcCfg[T]) OnUpdate(old, new *GrpcCfg[T]) {
 			}
 		})
 	}
+
+	var err error
+	new.grpcClient, err = grpcclient.New(new.clientFactory, grpcclient.WithConfig(&new.Config))
+	if err != nil {
+		klog.Errorf(ctx, "GrpcCfg.OnUpdate|grpcclient.New failed|err=%v", err)
+		return
+	}
+
+	new.C = new.grpcClient.C
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why did we need it?
- **Fix issue**: the new grpc client is accidentally closed when updating the new config.
In function `OnUpdate`, `old` and `new` have the same address. So, when we create a new grpc client and assign it to `new.grpcClient` in line 35, the `old.grpcClient` is also updated.
In line 44, we create a function to close the `old.grpcClient`, it is equivalent to closing the `new.grpcClient` → issue
https://github.com/KyberNetwork/service-framework/blob/1b3044328d01c6061c2bd1d8b5916be107ddae57/pkg/client/grpc.go#L32-L50

- **Solution**: Close the `old.grpcClient` before creating a new grpc client and assign it to `new.grpcClient`
## Related Issue

## Release Note
<!--- Please list out special notes (if any) when releasing this commit -->
<!--- Special notes is things like breaking changes and related components, required changes and env configurations in kyber-application, etc. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
